### PR TITLE
[Fix] Updated outdated GSON client

### DIFF
--- a/src/main/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationPlugin.java
+++ b/src/main/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationPlugin.java
@@ -60,6 +60,7 @@ import static net.runelite.client.plugins.banktags.BankTagsPlugin.*;
 public class WikiBankTagIntegrationPlugin extends Plugin {
 
     private static final String WIKI_QUERY_FORMAT = "https://oldschool.runescape.wiki/api.php?action=ask&query=%s|+limit=2000&format=json";
+    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
     @Inject
     private Client client;
@@ -252,7 +253,6 @@ public class WikiBankTagIntegrationPlugin extends Plugin {
      * @see AskQuery.Response
      */
     private int[] getIDsFromJSON(String jsonIn) {
-        Gson gson = new Gson();
         AskQuery.Response askResponse = gson.fromJson(jsonIn, AskQuery.Response.class);
         return askResponse.getQuery().getResults().values()
                 .stream()


### PR DESCRIPTION
This updated the usage of GSON

According to the build error log on plugin-hub [here](https://github.com/runelite/plugin-hub/actions/runs/9525422496/job/26259532389?pr=6171)

We are no longer able to do 

```
Gson gson = new Gson()
```

Instead, it appears the new syntax is how I have it in my changeset. 

Tested this locally and it appears to work. Will confirm with the build once we merge this into this repo