### PR TITLE
[Fix] plugin hub build error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.16'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/mitchbarnett/wikibanktagintegration/AskQuery.java
+++ b/src/main/java/com/mitchbarnett/wikibanktagintegration/AskQuery.java
@@ -1,3 +1,5 @@
+package com.mitchbarnett.wikibanktagintegration;
+
 /*
  * Copyright (c) 2020 Mitch Barnett <mitch@mitchbarnett.com Discord: Wizard Mitch#5072 Reddit: Wizard_Mitch>
  * All rights reserved.
@@ -22,8 +24,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-package net.runelite.client.plugins.wikibanktagintegration.src.main.java.com.mitchbarnett.wikibanktagintegration;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;

--- a/src/main/java/com/mitchbarnett/wikibanktagintegration/AskQuery.java
+++ b/src/main/java/com/mitchbarnett/wikibanktagintegration/AskQuery.java
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.mitchbarnett.wikibanktagintegration;
+package net.runelite.client.plugins.wikibanktagintegration.src.main.java.com.mitchbarnett.wikibanktagintegration;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 
 interface AskQuery {
-    
+
     @Data
     class Response {
         @SerializedName("query-continue-offset")
@@ -85,4 +85,3 @@ interface AskQuery {
         private String displaytitle;
     }
 }
-

--- a/src/main/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationConfig.java
+++ b/src/main/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationConfig.java
@@ -1,3 +1,5 @@
+package net.runelite.client.plugins.wikibanktagintegration.src.main.java.com.mitchbarnett.wikibanktagintegration;
+
 /*
  * Copyright (c) 2020 Mitch Barnett <mitch@mitchbarnett.com Discord: Wizard Mitch#5072 Reddit: Wizard_Mitch>
  * All rights reserved.
@@ -23,8 +25,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.mitchbarnett.wikibanktagintegration;
-
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -32,23 +32,23 @@ import net.runelite.client.config.ConfigItem;
 @ConfigGroup("wikibanktagintegration")
 public interface WikiBankTagIntegrationConfig extends Config
 {
-	@ConfigItem(
-		keyName = "categoryChatCommand",
-		name = "Category chat command",
-		description = "The chat command to  make a tab from a wiki category"
-	)
-	default String categoryChatCommand()
-	{
-		return "btCat";
-	}
+    @ConfigItem(
+            keyName = "categoryChatCommand",
+            name = "Category chat command",
+            description = "The chat command to  make a tab from a wiki category"
+    )
+    default String categoryChatCommand()
+    {
+        return "btCat";
+    }
 
-	@ConfigItem(
-		keyName = "dropsChatCommand",
-		name = "Drops chat command",
-		description = "The chat command to make a tab from the drops of a monster"
-	)
-	default String dropsChatCommand()
-	{
-		return "btDrops";
-	}
+    @ConfigItem(
+            keyName = "dropsChatCommand",
+            name = "Drops chat command",
+            description = "The chat command to make a tab from the drops of a monster"
+    )
+    default String dropsChatCommand()
+    {
+        return "btDrops";
+    }
 }

--- a/src/main/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationConfig.java
+++ b/src/main/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationConfig.java
@@ -1,4 +1,4 @@
-package net.runelite.client.plugins.wikibanktagintegration.src.main.java.com.mitchbarnett.wikibanktagintegration;
+package com.mitchbarnett.wikibanktagintegration;
 
 /*
  * Copyright (c) 2020 Mitch Barnett <mitch@mitchbarnett.com Discord: Wizard Mitch#5072 Reddit: Wizard_Mitch>

--- a/src/main/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationPlugin.java
+++ b/src/main/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationPlugin.java
@@ -1,3 +1,5 @@
+package net.runelite.client.plugins.wikibanktagintegration.src.main.java.com.mitchbarnett.wikibanktagintegration;
+
 /*
  * Copyright (c) 2020 Mitch Barnett <mitch@mitchbarnett.com Discord: Wizard Mitch#5072 Reddit: Wizard_Mitch>
  * All rights reserved.
@@ -22,8 +24,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-package com.mitchbarnett.wikibanktagintegration;
 
 import com.google.common.base.MoreObjects;
 import com.google.gson.Gson;
@@ -181,7 +181,7 @@ public class WikiBankTagIntegrationPlugin extends Plugin {
      * @param category The name of the OSRS wiki category that will be Item Ids will be generated from
      * @return A list of Item IDs found for the provided category.
      */
-    int[] getCategoryIDs(String category) {
+    public int[] getCategoryIDs(String category) {
         try {
             String safe_query = URLEncoder.encode(category, "UTF-8");
             String query = String.format("[[category:%s]]|?All+Item+ID", safe_query);
@@ -204,7 +204,7 @@ public class WikiBankTagIntegrationPlugin extends Plugin {
      * @param monster The name of the OSRS monster that will be Item Ids will be generated from
      * @return A list of Item IDs found for the provided category.
      */
-    int[] getDropIDs(String monster) {
+    public int[] getDropIDs(String monster) {
         try {
             String safe_query = URLEncoder.encode(monster, "UTF-8");
             String query = String.format("[[Dropped from::%s]]|?Dropped item.All+Item+ID", safe_query);
@@ -262,4 +262,3 @@ public class WikiBankTagIntegrationPlugin extends Plugin {
                 .toArray();
     }
 }
-

--- a/src/main/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationPlugin.java
+++ b/src/main/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationPlugin.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.wikibanktagintegration.src.main.java.com.mit
 
 import com.google.common.base.MoreObjects;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;

--- a/src/main/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationPlugin.java
+++ b/src/main/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationPlugin.java
@@ -172,7 +172,7 @@ public class WikiBankTagIntegrationPlugin extends Plugin {
         String tags = Text.toCSV(tabs);
 
         configManager.setConfiguration(CONFIG_GROUP, TAG_TABS_CONFIG, tags);
-        configManager.setConfiguration(CONFIG_GROUP, ICON_SEARCH + Text.standardize(tag), iconItemId);
+        configManager.setConfiguration(CONFIG_GROUP, TAG_ICON_PREFIX + Text.standardize(tag), iconItemId);
 
     }
 
@@ -208,7 +208,7 @@ public class WikiBankTagIntegrationPlugin extends Plugin {
     public int[] getDropIDs(String monster) {
         try {
             String safe_query = URLEncoder.encode(monster, "UTF-8");
-            String query = String.format("[[Dropped from::%s]]|?Dropped item.All+Item+ID", safe_query);
+            String query = String.format("[[Dropped from::%s]]|?Dropped item page.All+Item+ID", safe_query);
             String wikiResponse = Objects.requireNonNull(getWikiResponse(query).body()).string();
             return getIDsFromJSON(wikiResponse);
         } catch (IOException e) {

--- a/src/main/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationPlugin.java
+++ b/src/main/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationPlugin.java
@@ -1,4 +1,4 @@
-package net.runelite.client.plugins.wikibanktagintegration.src.main.java.com.mitchbarnett.wikibanktagintegration;
+package com.mitchbarnett.wikibanktagintegration;
 
 /*
  * Copyright (c) 2020 Mitch Barnett <mitch@mitchbarnett.com Discord: Wizard Mitch#5072 Reddit: Wizard_Mitch>

--- a/src/main/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationPlugin.java
+++ b/src/main/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationPlugin.java
@@ -60,6 +60,7 @@ import static net.runelite.client.plugins.banktags.BankTagsPlugin.*;
 public class WikiBankTagIntegrationPlugin extends Plugin {
 
     private static final String WIKI_QUERY_FORMAT = "https://oldschool.runescape.wiki/api.php?action=ask&query=%s|+limit=2000&format=json";
+    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
     @Inject
     private Client client;
@@ -252,7 +253,6 @@ public class WikiBankTagIntegrationPlugin extends Plugin {
      * @see AskQuery.Response
      */
     private int[] getIDsFromJSON(String jsonIn) {
-        Gson gson = new Gson();
         AskQuery.Response askResponse = gson.fromJson(jsonIn, AskQuery.Response.class);
         return askResponse.getQuery().getResults().values()
                 .stream()

--- a/src/test/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationPluginTest.java
+++ b/src/test/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationPluginTest.java
@@ -1,3 +1,5 @@
+package net.runelite.client.plugins.wikibanktagintegration.src.test.java.com.mitchbarnett.wikibanktagintegration;
+
 /*
  * Copyright (c) 2020 Mitch Barnett <mitch@mitchbarnett.com Discord: Wizard Mitch#5072 Reddit: Wizard_Mitch>
  * All rights reserved.
@@ -23,18 +25,17 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.mitchbarnett.wikibanktagintegration;
-
 import net.runelite.client.RuneLite;
 import net.runelite.client.externalplugins.ExternalPluginManager;
+import net.runelite.client.plugins.wikibanktagintegration.src.main.java.com.mitchbarnett.wikibanktagintegration.WikiBankTagIntegrationPlugin;
 
 public class WikiBankTagIntegrationPluginTest
 {
-	public static void main(String[] args) throws Exception
-	{
-		//noinspection unchecked
-		ExternalPluginManager.loadBuiltin(WikiBankTagIntegrationPlugin.class);
-		RuneLite.main(args);
-	}
+    public static void main(String[] args) throws Exception
+    {
+        //noinspection unchecked
+        ExternalPluginManager.loadBuiltin(WikiBankTagIntegrationPlugin.class);
+        RuneLite.main(args);
+    }
 
 }

--- a/src/test/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationPluginTest.java
+++ b/src/test/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagIntegrationPluginTest.java
@@ -1,4 +1,4 @@
-package net.runelite.client.plugins.wikibanktagintegration.src.test.java.com.mitchbarnett.wikibanktagintegration;
+package com.mitchbarnett.wikibanktagintegration;
 
 /*
  * Copyright (c) 2020 Mitch Barnett <mitch@mitchbarnett.com Discord: Wizard Mitch#5072 Reddit: Wizard_Mitch>
@@ -27,7 +27,7 @@ package net.runelite.client.plugins.wikibanktagintegration.src.test.java.com.mit
 
 import net.runelite.client.RuneLite;
 import net.runelite.client.externalplugins.ExternalPluginManager;
-import net.runelite.client.plugins.wikibanktagintegration.src.main.java.com.mitchbarnett.wikibanktagintegration.WikiBankTagIntegrationPlugin;
+import com.mitchbarnett.wikibanktagintegration.WikiBankTagIntegrationPlugin;
 
 public class WikiBankTagIntegrationPluginTest
 {

--- a/src/test/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagQueryTest.java
+++ b/src/test/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagQueryTest.java
@@ -1,5 +1,6 @@
-package com.mitchbarnett.wikibanktagintegration;
+package net.runelite.client.plugins.wikibanktagintegration.src.test.java.com.mitchbarnett.wikibanktagintegration;
 
+import net.runelite.client.plugins.wikibanktagintegration.src.main.java.com.mitchbarnett.wikibanktagintegration.WikiBankTagIntegrationPlugin;
 import okhttp3.OkHttpClient;
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagQueryTest.java
+++ b/src/test/java/com/mitchbarnett/wikibanktagintegration/WikiBankTagQueryTest.java
@@ -1,6 +1,6 @@
-package net.runelite.client.plugins.wikibanktagintegration.src.test.java.com.mitchbarnett.wikibanktagintegration;
+package com.mitchbarnett.wikibanktagintegration;
 
-import net.runelite.client.plugins.wikibanktagintegration.src.main.java.com.mitchbarnett.wikibanktagintegration.WikiBankTagIntegrationPlugin;
+import com.mitchbarnett.wikibanktagintegration.WikiBankTagIntegrationPlugin;
 import okhttp3.OkHttpClient;
 import org.junit.Assert;
 import org.junit.Before;


### PR DESCRIPTION
This updated the usage of GSON

According to the build error log on plugin-hub [here](https://github.com/runelite/plugin-hub/actions/runs/9525422496/job/26259532389?pr=6171)

We are no longer able to do

Gson gson = new Gson()
Instead, it appears the new syntax is how I have it in my changeset.

Tested this locally and it appears to work. Will confirm with the build once we merge this into this repo

This update also includes some cleanup I did as I went through this plugin inside of the runelite project locally